### PR TITLE
Fix output, rename variables

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,7 +51,7 @@ const String data_header =
     "bno_rate_x,bno_rate_y,bno_rate_z,"
     "bno_accel_x,bno_accel_y,bno_accel_z,"
     "adxl_accel_x,adxl_accel_y,adxl_accel_z,"
-    "pressure,altitude,"
+    "bmp_pressure,bmp_altitude,"
     "lsm_temp,adxl_temp,bno_temp,bmp_temp,"
     "lsm_status,bmp_status,adxl_status,bno_status,gps_status";
 


### PR DESCRIPTION
Adding the gyro acceleration output, fixed pressure and altitude variable names to reflect that they're from the BMP